### PR TITLE
adds comment_count to GET review response

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -26,7 +26,7 @@ describe("GET /api/categories", () => {
   });
 });
 
-describe.only("GET /api/reviews/:review_id", () => {
+describe("GET /api/reviews/:review_id", () => {
   it("should return status 200, responds with a review object", () => {
     return request(app)
       .get("/api/reviews/2")
@@ -46,7 +46,7 @@ describe.only("GET /api/reviews/:review_id", () => {
           comment_count: expect.any(String),
         };
         expect(reviewObject).toMatchObject(expectedReview);
-        expect(typeof +reviewObject.comment_count).toBe("number");
+        expect(reviewObject.comment_count).toBe("3");
       });
   });
   it("should return status 404 when reponding to a review_id that does not exist", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -26,7 +26,7 @@ describe("GET /api/categories", () => {
   });
 });
 
-describe("GET /api/reviews/:review_id", () => {
+describe.only("GET /api/reviews/:review_id", () => {
   it("should return status 200, responds with a review object", () => {
     return request(app)
       .get("/api/reviews/2")
@@ -43,8 +43,10 @@ describe("GET /api/reviews/:review_id", () => {
           category: expect.any(String),
           created_at: expect.any(String),
           votes: expect.any(Number),
+          comment_count: expect.any(String),
         };
         expect(reviewObject).toMatchObject(expectedReview);
+        expect(typeof +reviewObject.comment_count).toBe("number");
       });
   });
   it("should return status 404 when reponding to a review_id that does not exist", () => {
@@ -99,8 +101,8 @@ describe("GET /api/reviews", () => {
       .then((response) => {
         const reviewsArray = response.body.reviews;
         expect(reviewsArray.length).toBe(11);
-        reviewsArray.forEach(review => {
-            expect(review.category).toBe("social deduction")
+        reviewsArray.forEach((review) => {
+          expect(review.category).toBe("social deduction");
         });
       });
   });

--- a/controllers.js
+++ b/controllers.js
@@ -36,7 +36,7 @@ exports.getReviews = (req, res, next) => {
   if (category) {
     getPromises.push(checkExists("categories", "slug", category));
   }
-  
+
   Promise.all(getPromises)
     .then((response) => {
       res.status(200).send({ reviews: response[0] });

--- a/models.js
+++ b/models.js
@@ -7,9 +7,15 @@ exports.fetchCategories = () => {
   });
 };
 
-exports.fetchReview = (reviewID, next) => {
+exports.fetchReview = (reviewID) => {
   const queryString = `
-	SELECT * FROM reviews WHERE reviews.review_id = $1;
+	SELECT reviews.* , COUNT(comments.review_id) AS comment_count 
+    FROM 
+    reviews
+    JOIN comments ON reviews.review_id = comments.review_id 
+    WHERE 
+    reviews.review_id = $1
+    GROUP BY reviews.review_id;
 	`;
   return db.query(queryString, [reviewID]).then((response) => {
     if (response.rows.length === 0) {
@@ -75,7 +81,10 @@ exports.checkExists = (table, column, value) => {
   const queryString = format(`SELECT * FROM %I WHERE %I = $1;`, table, column);
   return db.query(queryString, [value]).then((response) => {
     if (response.rows.length === 0) {
-      return Promise.reject({ status: 404, message: `${table} ${column} not found` });
+      return Promise.reject({
+        status: 404,
+        message: `${table} ${column} not found`,
+      });
     }
   });
 };


### PR DESCRIPTION
Currently testing with toMatchObject per previous comments, added test to ensure comment_count is a string of a number. I could add simple check to see if comment_count is correct value but unsure if this would be the right approach as it conflicts with the reasoning for using toMatchObject as opposed to toEqual